### PR TITLE
update the plugin parent version so hpi:run works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29</version>
+    <version>3.31</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
without this - hpi:run will fail with: 

```
[ERROR] Failed to execute goal org.jenkins-ci.tools:maven-hpi-plugin:3.0:run (default-cli) on project simple-theme-plugin: minimumJavaVersion attribute must be set starting from version 2.8 -> [Help 1]
```

I found this out by googling the error message.