### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,3 +64,9 @@ The MIT License (MIT)
 - Copyright (c) 2018 TobiX
 
 See [LICENSE](LICENSE)
+
+## Changelog
+
+* See [GitHub Releases](https://github.com/jenkinsci/simple-theme-plugin/releases) for the recent versions
+* See the [plugin's Wiki page](https://wiki.jenkins.io/display/JENKINS/Simple+Theme+Plugin) for versions 0.5.1 and older
+

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <description>This plugin allows to customize Jenkin's appearance with custom
     CSS and JavaScript. It also allows to replace the Favicon.
   </description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Simple+Theme+Plugin</url>
+  <url>https://github.com/jenkinsci/simple-theme-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>


### PR DESCRIPTION
Just to avoid maintaining docs in two places.
See the developer thread for announcements: https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A

