### PR TITLE
Update Jenkins baseline to 2.204

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
 #!groovy
-
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+def recentLTS = "2.277.4"
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+  [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.56</version>
+    <version>4.18</version>
     <relativePath />
   </parent>
 
@@ -43,8 +43,8 @@
   <properties>
     <revision>0.7</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.121.3</jenkins.version>
-    <configuration-as-code.version>1.27</configuration-as-code.version>
+    <jenkins.version>2.204</jenkins.version>
+    <configuration-as-code.version>1.36</configuration-as-code.version>
     <java.level>8</java.level>
   </properties>
 
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.17</version>
+      <version>1.21</version>
       <scope>provided</scope>
     </dependency>
 
@@ -63,10 +63,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <version>${configuration-as-code.version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -97,7 +96,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.9.1</version>
         <executions>
           <!-- Fail build if code is not properly formatted -->
           <execution>

--- a/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationAsCodeTest.java
@@ -3,13 +3,13 @@ package org.jenkinsci.plugins.simpletheme;
 import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
 import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;

--- a/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationMigrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationMigrationTest.java
@@ -1,11 +1,11 @@
 package org.jenkinsci.plugins.simpletheme;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 import org.codefirst.SimpleThemeDecorator;
 import org.junit.Rule;

--- a/src/test/java/org/jenkinsci/plugins/simpletheme/SimpleThemeConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/simpletheme/SimpleThemeConfigurationTest.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.plugins.simpletheme;
 
 import static com.gargoylesoftware.htmlunit.WebAssert.assertElementPresentByXPath;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;


### PR DESCRIPTION
Just some light maintenance work... While this isn't strictly necessary, this gets rid of another implied dependency.

While looking at https://stats.jenkins.io/pluginversions/simple-theme-plugin.html always makes me a bit sad, this allows about ~96% of users of the latest version to update.