### PR TITLE
remove inline js for favicon

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/simpletheme/FaviconUrlThemeElement.java
+++ b/src/main/java/org/jenkinsci/plugins/simpletheme/FaviconUrlThemeElement.java
@@ -11,9 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class FaviconUrlThemeElement extends UrlThemeElement {
 
     private static final String SCRIPT_INCLUDE =
-            "<script src=\"{0}/plugin/simple-theme-plugin/simple-theme.js\"></script>";
-    private static final String FAVICON_SCRIPT =
-            "<script>\n" + "window[''org.jenkinsci.plugins.simpletheme''].replaceFavicon(\"{0}\");\n" + "</script>";
+            "<script id=\"simple-theme-script\" data-url=\"{0}\" src=\"{1}/plugin/simple-theme-plugin/simple-theme.js\"></script>";
 
     @DataBoundConstructor
     public FaviconUrlThemeElement(String url) {
@@ -22,8 +20,8 @@ public class FaviconUrlThemeElement extends UrlThemeElement {
 
     @Override
     public void collectHeaderFragment(Set<String> fragments, boolean injectCss) {
-        fragments.add(MessageFormat.format(SCRIPT_INCLUDE, Jenkins.get().getRootUrlFromRequest()));
-        fragments.add(MessageFormat.format(FAVICON_SCRIPT, getUrl()));
+        fragments.add(
+                MessageFormat.format(SCRIPT_INCLUDE, getUrl(), Jenkins.get().getRootUrlFromRequest()));
     }
 
     @Extension

--- a/src/main/webapp/simple-theme.js
+++ b/src/main/webapp/simple-theme.js
@@ -2,32 +2,26 @@
     "use strict";
 
     function removeAll() {
-        var links = Array.from(document.getElementsByTagName('link')),
-            link, i;
+        const links = document.getElementsByTagName('link');
 
-        for (i = 0; i < links.length; i++) {
-            link = links[i];
+        for (const link of links) {
             if (link.rel.split(/\s+/).some(e => e === 'icon')) {
-                link.parentNode.removeChild(link);
+                link.remove();
             }
         }
     }
 
     function add(url) {
-        var link = document.createElement('link');
+        const link = document.createElement('link');
         link.setAttribute('rel', 'icon');
         document.getElementsByTagName('head')[0].appendChild(link);
         link.setAttribute('href', url);
     }
 
-    function replaceFavicon(url) {
-        document.addEventListener("DOMContentLoaded", function(event) {
-            removeAll();
-            add(url);
-        });
-    }
+    document.addEventListener("DOMContentLoaded", function(event) {
+        const script = document.getElementById("simple-theme-script");
+        removeAll();
+        add(script.dataset.url);
+    });
 
-    global['org.jenkinsci.plugins.simpletheme'] = {
-        replaceFavicon: replaceFavicon
-    };
 })(this, document);

--- a/src/test/java/org/jenkinsci/plugins/simpletheme/SimpleThemeConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/simpletheme/SimpleThemeConfigurationTest.java
@@ -59,7 +59,7 @@ public class SimpleThemeConfigurationTest {
         assertElementPresentByXPath(page, "//script[contains(@src,'SOMEJS.js')]");
 
         assertElementPresentByXPath(page, "//script[contains(@src,'simple-theme.js')]");
-        assertElementPresentByXPath(page, "//script[contains(text(),'FAVICON.png')]");
+        assertElementPresentByXPath(page, "//script[contains(@data-url,'FAVICON.png')]");
     }
 
     private void fill(SimpleThemeDecorator decorator) {


### PR DESCRIPTION
favicon generates inline js which is not CSP compliant. This changes it so the url is provided via a data-url attribute of the script.
Also simplifies a bit the javascript and uses modern syntax.

<!-- Please describe your pull request here. -->

### Testing done
Manual testing that favicon still works
Verified with CSP plugin that there are no errors related to favicon

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
